### PR TITLE
Update dependencies for TrustyAI 0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-trustyai==0.2.8
-joblib==1.0.1
-jupyterlab==3.4.3
-pandas==1.2.5
-scikit-learn==1.0.2
+trustyai==0.2.9
+joblib~=1.1.1
+jupyterlab~=3.5.3
+pandas~=1.5.3
+scikit-learn~=1.2.1
 xgboost==1.4.2
-matplotlib==3.5.1
+matplotlib~=3.6.3


### PR DESCRIPTION
Update examples dependencies to TrustyAI 0.2.9 and to match Open Data Hub Workbench images.

Closes #23 